### PR TITLE
4 configure vs code settings and prettier for consistent formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true,
+  "printWidth": 100
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
-  "singleQuote": true,
-  "trailingComma": "es5",
   "semi": true,
-  "printWidth": 100
+  "trailingComma": "es5",
+  "printWidth": 120,
+  "tabWidth": 2
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,18 @@
 {
   "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": ["typescript", "typescriptreact"],
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "editor.tabSize": 2,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "workbench.editorAssociations": {
+    "*.svg": "default"
   }
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   _Reason:_ Ideal for managing state in small to medium apps. If state complexity grows, Zustand can be considered due to its minimal API and performance advantages.
 
 - **Audio Input Support:**
+
   - **Audio Capture:** Web Speech API or third-party browser-compatible libraries.
   - **Speech-to-Text:** Google Cloud Speech-to-Text to convert audio to text.
   - **Text Processing:** Send the transcribed text to the ChatGPT API (starting with GPT-3.5 Turbo for cost-effectiveness, with the option to switch to GPT-4 if needed).
@@ -49,4 +50,3 @@
 - **Automated Reports:** Enable users to generate and download periodic reports (CSV, PDF, or JSON) of their health logs for backup or sharing.
 
 ---
-

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,16 +54,14 @@ export default tseslint.config(
           patterns: [
             {
               group: ['../*', '../*/*', '../../*'],
-              message: 'Please use absolute paths with the ~ prefix instead of relative parent paths.',
+              message:
+                'Please use absolute paths with the ~ prefix instead of relative parent paths.',
             },
           ],
         },
       ],
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'simple-import-sort/imports': [
         'error',
         {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from 'react';
+import reactLogo from './assets/react.svg';
+import viteLogo from '/vite.svg';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
 
   return (
     <>
@@ -18,18 +18,14 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,5 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,5 @@
     }
   },
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});


### PR DESCRIPTION
Installed Prettier as a dev dependency.

Created a Prettier configuration file in the root of the project:
   - .prettierrc

Created a Prettier ignore file to exclude certain files/folders:
   - .prettierignore

Added a format script to package.json.

Created VS Code workspace settings to enforce formatting on save:
   - .vscode/settings.json file

I ran npm run format - changes are visible to files in this commit from Prettier.