### PR TITLE
5 add husky for pre commit checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint && npm run format

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint && npm run format
+npm run lint && npm run tsc && npm run format
+
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,95 +1,94 @@
-import js from '@eslint/js';
-import globals from 'globals';
-import reactHooks from 'eslint-plugin-react-hooks';
-import reactRefresh from 'eslint-plugin-react-refresh';
-import tseslint from 'typescript-eslint';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
-import prettier from 'eslint-plugin-prettier';
-import react from 'eslint-plugin-react';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import prettier from "eslint-plugin-prettier";
+import react from "eslint-plugin-react";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 export default tseslint.config(
   {
     ignores: [
-      'node_modules',
-      'dist',
-      'dist-ssr',
-      '*.local',
-      'logs',
-      '*.log',
-      'npm-debug.log*',
-      'yarn-debug.log*',
-      'yarn-error.log*',
-      'pnpm-debug.log*',
-      'lerna-debug.log*',
-      '.vscode/*',
-      '.idea',
-      '.DS_Store',
-      '*.suo',
-      '*.ntvs*',
-      '*.njsproj',
-      '*.sln',
-      '*.sw?',
+      "node_modules",
+      "dist",
+      "dist-ssr",
+      "*.local",
+      "logs",
+      "*.log",
+      "npm-debug.log*",
+      "yarn-debug.log*",
+      "yarn-error.log*",
+      "pnpm-debug.log*",
+      "lerna-debug.log*",
+      ".vscode/*",
+      ".idea",
+      ".DS_Store",
+      "*.suo",
+      "*.ntvs*",
+      "*.njsproj",
+      "*.sln",
+      "*.sw?",
     ],
   },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-      'jsx-a11y': jsxA11y,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+      "jsx-a11y": jsxA11y,
       prettier: prettier,
       react: react,
-      'simple-import-sort': simpleImportSort,
+      "simple-import-sort": simpleImportSort,
     },
     rules: {
-      'no-restricted-imports': [
-        'error',
+      "no-restricted-imports": [
+        "error",
         {
           patterns: [
             {
-              group: ['../*', '../*/*', '../../*'],
-              message:
-                'Please use absolute paths with the ~ prefix instead of relative parent paths.',
+              group: ["../*", "../*/*", "../../*"],
+              message: "Please use absolute paths with the ~ prefix instead of relative parent paths.",
             },
           ],
         },
       ],
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-      'simple-import-sort/imports': [
-        'error',
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "simple-import-sort/imports": [
+        "error",
         {
           groups: [
             [
-              '^react', // React-related packages first
-              '^@?\\w', // Third-party packages
-              '^\\.\\.(?!/?$)', // Parent imports
-              '^\\.\\./?$', // Parent folder index
-              '^\\./(?=.*/)(?!/?$)', // Nested relative imports
-              '^\\.(?!/?$)', // Current folder imports
-              '^\\./?$', // Current folder index
+              "^react", // React-related packages first
+              "^@?\\w", // Third-party packages
+              "^\\.\\.(?!/?$)", // Parent imports
+              "^\\.\\./?$", // Parent folder index
+              "^\\./(?=.*/)(?!/?$)", // Nested relative imports
+              "^\\.(?!/?$)", // Current folder imports
+              "^\\./?$", // Current folder index
             ],
           ],
         },
       ],
-      'react-hooks/rules-of-hooks': ['error'],
-      'react/jsx-key': ['error'],
-      'react/jsx-tag-spacing': [
-        'error',
+      "react-hooks/rules-of-hooks": ["error"],
+      "react/jsx-key": ["error"],
+      "react/jsx-tag-spacing": [
+        "error",
         {
-          closingSlash: 'never',
-          beforeSelfClosing: 'always',
-          afterOpening: 'never',
-          beforeClosing: 'allow',
+          closingSlash: "never",
+          beforeSelfClosing: "always",
+          afterOpening: "never",
+          beforeClosing: "allow",
         },
       ],
-      'prettier/prettier': 'error',
+      "prettier/prettier": "error",
     },
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "globals": "^16.0.0",
-        "husky": "^8.0.3",
+        "husky": "^8.0.0",
         "prettier": "^3.5.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
@@ -3279,16 +3279,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "globals": "^16.0.0",
+        "husky": "^9.1.7",
         "prettier": "^3.5.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
@@ -3275,6 +3276,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "globals": "^16.0.0",
-        "husky": "^9.1.7",
+        "husky": "^8.0.3",
         "prettier": "^3.5.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
@@ -3279,16 +3279,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "bin.js"
+        "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepare": "husky"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -30,6 +31,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.0.0",
+    "husky": "^9.1.7",
     "prettier": "^3.5.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "format": "prettier --write .",
-    "prepare": "husky"
+    "prepare": "husky install"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -31,7 +31,6 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.0.0",
-    "husky": "^9.1.7",
     "prettier": "^3.5.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "format": "prettier --write .",
+    "tsc": "tsc -b",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -31,6 +32,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.0.0",
+    "husky": "^8.0.0",
     "prettier": "^3.5.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
-import './App.css';
+import { useState } from "react";
+import reactLogo from "./assets/react.svg";
+
+import "./App.css";
+import viteLogo from "/vite.svg";
 
 function App() {
   const [count, setCount] = useState(0);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App.tsx';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
   </StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Had a few changes to the process but I think it's working fine as tested ( I removed semicolons etc from package.json and it blocked the commit).

The changes were that Husky v8+ no longer recommends using npx husky add. Instead, you're expected to manually create the hook files.


Husky v9+ no longer uses the . "$(dirname "$0")/_/husky.sh" line in hook scripts.


Do we want Husky to automatically fix what it can before blocking? The hook can be updated as follows :

#!/bin/sh
npm run lint -- --fix && npm run format

This ensures:
* ESLint auto-fixes what it can
* Prettier runs after to format consistently


I noticed we are using the older Husky in the mobile version, should that be updated too? Or is it better to downgrade this version if we are further into mobile?
