### PR TITLE
21 Implement Symptons Form Section

### DIFF
--- a/src/components/SymptomFormSection.css
+++ b/src/components/SymptomFormSection.css
@@ -1,0 +1,120 @@
+.symptom-form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: auto;
+  max-width: 700px;
+}
+
+.symptom-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  background-color: #fafafa;
+  transition: box-shadow 0.4s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.symptom-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  border-bottom: 1px solid #ccc;
+}
+
+.symptom-header:hover {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+}
+
+.symptom-header h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #333;
+}
+
+.symptom-body {
+  display: flex;
+  flex-direction: column;
+  margin-top: 1rem;
+  gap: 0.5rem;
+}
+
+.symptom-body label {
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.symptom-body input {
+  padding: 0.5rem;
+  border: 2px solid #ccc;
+  border-radius: 6px;
+  width: 100%;
+  transition: border 0.3s;
+}
+
+.symptom-body input:focus {
+  border-color: #007bff;
+  outline: none;
+}
+
+.placeholder {
+  padding: 0.5rem;
+  background-color: #eee;
+  border-radius: 4px;
+  color: #555;
+}
+
+button.add-button,
+button.remove-button {
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: white;
+  cursor: pointer;
+}
+
+button.add-button {
+  background-color: #007bff;
+}
+
+button.add-button:hover {
+  background-color: #0056b3;
+}
+
+button.remove-button {
+  background-color: #dc3545;
+}
+
+button.remove-button:hover {
+  background-color: #c82333;
+}
+
+.update-button {
+  background-color: #4CAF50;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 6px;
+  margin-top: 1rem;
+  cursor: pointer;
+}
+
+.update-button:disabled {
+  cursor: none;
+  opacity: 0.5;
+}
+
+.update-button:hover{
+    background-color: #45a049;
+}
+
+.success-message {
+  color: #45a049;
+  padding: 10px 15px;
+  margin-bottom: 1rem;
+  border: 1px solid #c3e6cb;
+  border-radius: 4px;
+  font-weight: bold;
+}

--- a/src/components/SymptomFormSection.tsx
+++ b/src/components/SymptomFormSection.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+
+import "./SymptomFormSection.css";
+
+type Symptom = {
+  name: string;
+  startDate: string;
+  affectedParts: string;
+  isOpen?: boolean;
+};
+
+const SymptomFormSection = () => {
+  const [symptoms, setSymptoms] = useState<Symptom[]>([]);
+  const [successMessage, setSuccessMessage] = useState("");
+
+  useEffect(() => {
+    fetch("/db.json")
+      .then((response) => response.json())
+      .then((data) => {
+        const records = data["health-records"];
+        const Record = records?.[0];
+        const loadedSymptoms = (Record.symptoms || []).map((s: Symptom) => ({
+          ...s,
+          isOpen: true,
+        }));
+        setSymptoms(loadedSymptoms);
+      })
+      .catch((error) => {
+        console.error("Error loading symptoms: ", error);
+      });
+  }, []);
+
+  const handleChange = (index: number, field: keyof Symptom, value: string) => {
+    const update = [...symptoms];
+    (update[index] as any)[field] = value;
+    setSymptoms(update);
+  };
+
+  const handleUpdate = () => {
+    console.log("Updated Symptoms:", symptoms);
+    setSuccessMessage("Symptoms successfully updated");
+  };
+
+  const isValid = () => {
+    return symptoms.every((s) => s.name.trim() && s.startDate.trim());
+  };
+
+  const toggleCol = (index: number) => {
+    const update = [...symptoms];
+    update[index].isOpen = !update[index].isOpen;
+    setSymptoms(update);
+  };
+
+  const addSymptom = () => {
+    setSymptoms([
+      ...symptoms,
+      { name: "", startDate: "", affectedParts: "Placeholder: affected parts coming soon", isOpen: true },
+    ]);
+  };
+
+  const removeSymptom = (index: number) => {
+    const update = symptoms.filter((_, i) => i !== index);
+    setSymptoms(update);
+  };
+
+  return (
+    <div className="symptom-form-container">
+      <h2>Symptoms</h2>
+      {symptoms.map((symptom, index) => (
+        <div key={index} className="symptom-card">
+          <div className="symptom-header" onClick={() => toggleCol(index)}>
+            <h4>Symptom {index + 1}</h4>
+            <button className="update-button" onClick={handleUpdate} disabled={!isValid()}>
+              Update Symptoms
+            </button>
+          </div>
+
+          {symptom.isOpen && (
+            <div className="symptom-body">
+              <label>Name</label>
+              <input
+                type="text"
+                value={symptom.name}
+                onChange={(e) => handleChange(index, "name", e.target.value)}
+                placeholder="Enter symptom name"
+              />
+
+              <label>Start Date</label>
+              <input
+                type="date"
+                value={symptom.startDate}
+                onChange={(e) => handleChange(index, "startDate", e.target.value)}
+              />
+
+              <label>Affected Parts</label>
+              <div className="placeholder">{symptom.affectedParts}</div>
+              <button
+                className="remove-button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeSymptom(index);
+                }}
+              >
+                {" "}
+                Remove{" "}
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+      <button className="add-button" onClick={addSymptom}>
+        {" "}
+        + Add Symptom
+      </button>
+      {successMessage && <div className="success-message">{successMessage}</div>}
+    </div>
+  );
+};
+
+export default SymptomFormSection;

--- a/src/pages/HealthRecord.tsx
+++ b/src/pages/HealthRecord.tsx
@@ -1,4 +1,5 @@
 import HealthCardList from "~/components/HealthCardList";
+import SymptomFormSection from "~/components/SymptomFormSection";
 
 const HealthRecord = () => (
   <div className="content-wrapper">
@@ -38,6 +39,7 @@ const HealthRecord = () => (
     </section>
 
     <HealthCardList />
+    <SymptomFormSection />
   </div>
 );
 


### PR DESCRIPTION
### Summary
Implemented the Symptoms Form Section for managing multiple symptoms in health record. Part of issue #21.
- Added: 
              - Add/Remove/Update Symptoms.
              - Expand/Collapse Symptoms details.
              - Placeholder on Affected Parts.
              - Display current Symptoms from db.json. 
              - Can Edit/Remove current Symptoms. (Doesn't affect the db.json. Waiting to be use in real database)
              - Feature to require users to fill the field before clicking update Symptoms.
              - CSS for styling and layout.
              Currently on Health Record Page. Waiting for #32  PR to be merged.

### How to Test
1. Run this cmd: npm run dev
2. Ctrl + Click on the localhost uri on terminal.
3. Navigate to the Symptoms section in the Health Record page.
4. Add, edit, and remove symptoms.
5. Ensure that the "Name" and "Start Date" inputs work.
6. Confirm collapsible cards expand/collapse and affected parts placeholder is visible.

### Checklist

- [ ] My code is up-to-date with the `main` branch.
- [ ] My code has no merge conflicts.
- [ ] I have performed a self-review of my code.
