### PR TITLE
45 contextual entry guided onboarding session persistence

### DIFF
--- a/db.json
+++ b/db.json
@@ -3,6 +3,7 @@
     {
       "id": 1,
       "user": "me",
+      "title": "Severe Migraine",
       "description": "Severe migraine lasting for days",
       "symptoms": [
         {
@@ -55,6 +56,7 @@
     {
       "id": 2,
       "user": "me",
+      "title": "Lower Back Pain",
       "description": "Persistent lower back pain affecting mobility",
       "symptoms": [
         {
@@ -101,6 +103,7 @@
     {
       "id": 3,
       "user": "me",
+      "title": "Seasonal Allergies",
       "description": "Seasonal allergies with severe symptoms",
       "symptoms": [
         {
@@ -137,6 +140,7 @@
     {
       "id": 4,
       "user": "me",
+      "title": "Knee Pain",
       "description": "Knee pain after sports injury",
       "symptoms": [
         {
@@ -179,6 +183,7 @@
     {
       "id": 5,
       "user": "me",
+      "title": "Digestive Problems",
       "description": "Persistent digestive issues",
       "symptoms": [
         {

--- a/src/components/HealthRecordForm.tsx
+++ b/src/components/HealthRecordForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import ChatWidget from "./chat/ChatWidget";
 
 import type { RecordFormData } from "~/types";
 
@@ -81,72 +82,75 @@ const HealthRecordForm = ({ recordFormData, setRecordFormData }: HealthRecordFor
   ) : error ? (
     <div style={{ color: "red" }}>Error: {error}</div>
   ) : (
-    <form className="form-wrapper" onSubmit={handleSubmit}>
-      <h2>Edit Health Record</h2>
-      <div className="form-group">
-        <label htmlFor="description">Description</label>
-        <textarea
-          id="description"
-          rows={4}
-          value={data.description}
-          onChange={(e) => handleDescriptionChange(e.target.value)}
-          placeholder="Describe symptoms, context, or notes..."
-        />
-      </div>
-      <div className="form-group">
-        <label>Treatments Tried</label>
-        <div className="treatment-input">
-          <input
-            type="text"
-            value={newTreatment}
-            onChange={(e) => setNewTreatment(e.target.value)}
-            placeholder="Enter a treatment"
+    <>
+      <form className="form-wrapper" onSubmit={handleSubmit}>
+        <h2>Edit Health Record</h2>
+        <div className="form-group">
+          <label htmlFor="description">Description</label>
+          <textarea
+            id="description"
+            rows={4}
+            value={data.description}
+            onChange={(e) => handleDescriptionChange(e.target.value)}
+            placeholder="Describe symptoms, context, or notes..."
           />
-          <button
-            type="button"
-            className={editIndex !== null ? "update-button" : "add-button"}
-            onClick={handleAddOrUpdateTreatment}
-          >
-            {editIndex !== null ? "Update" : "Add"}
-          </button>
         </div>
-        <ul className="treatment-list">
-          {data.treatmentsTried.map((treatment, i) => (
-            <li key={i}>
-              {treatment}
-              <div>
-                <button
-                  type="button"
-                  className="edit-button"
-                  style={{ marginRight: "0.5rem" }}
-                  onClick={() => handleEditTreatment(i)}
-                >
-                  Edit
-                </button>
-                <button type="button" className="remove-button" onClick={() => handleRemoveTreatment(i)}>
-                  Remove
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div className="form-group" style={{ fontSize: "0.7rem", color: "#555" }}>
-        {data.createdAt && (
-          <p>
-            <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
-          </p>
-        )}
-        {data.updatedAt && (
-          <p>
-            <strong>Updated:</strong> {new Date(data.updatedAt).toLocaleString()}
-          </p>
-        )}
-      </div>
-      <button type="submit" className="submit-button">
-        Submit
-      </button>
-    </form>
+        <div className="form-group">
+          <label>Treatments Tried</label>
+          <div className="treatment-input">
+            <input
+              type="text"
+              value={newTreatment}
+              onChange={(e) => setNewTreatment(e.target.value)}
+              placeholder="Enter a treatment"
+            />
+            <button
+              type="button"
+              className={editIndex !== null ? "update-button" : "add-button"}
+              onClick={handleAddOrUpdateTreatment}
+            >
+              {editIndex !== null ? "Update" : "Add"}
+            </button>
+          </div>
+          <ul className="treatment-list">
+            {data.treatmentsTried.map((treatment, i) => (
+              <li key={i}>
+                {treatment}
+                <div>
+                  <button
+                    type="button"
+                    className="edit-button"
+                    style={{ marginRight: "0.5rem" }}
+                    onClick={() => handleEditTreatment(i)}
+                  >
+                    Edit
+                  </button>
+                  <button type="button" className="remove-button" onClick={() => handleRemoveTreatment(i)}>
+                    Remove
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="form-group" style={{ fontSize: "0.7rem", color: "#555" }}>
+          {data.createdAt && (
+            <p>
+              <strong>Created:</strong> {new Date(data.createdAt).toLocaleString()}
+            </p>
+          )}
+          {data.updatedAt && (
+            <p>
+              <strong>Updated:</strong> {new Date(data.updatedAt).toLocaleString()}
+            </p>
+          )}
+        </div>
+        <button type="submit" className="submit-button">
+          Submit
+        </button>
+      </form>
+      <ChatWidget healthRecordId={data.id} />
+    </>
   );
 };
 

--- a/src/components/chat/ChatForm.tsx
+++ b/src/components/chat/ChatForm.tsx
@@ -7,9 +7,10 @@ import type { ChatHistoryType } from "~/types";
 interface ChatFormProps {
   setChatHistory: Dispatch<SetStateAction<ChatHistoryType[]>>;
   setIsThinking: Dispatch<SetStateAction<boolean>>;
+  disabled: boolean;
 }
 
-const ChatForm = ({ setChatHistory, setIsThinking }: ChatFormProps) => {
+const ChatForm = ({ setChatHistory, setIsThinking, disabled }: ChatFormProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleSendMessage = (e: FormEvent<HTMLFormElement>) => {
@@ -32,7 +33,14 @@ const ChatForm = ({ setChatHistory, setIsThinking }: ChatFormProps) => {
 
   return (
     <form className="chat-form" onSubmit={handleSendMessage}>
-      <input ref={inputRef} type="text" placeholder="Message..." className="chat-message-input" required />
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="Message..."
+        className="chat-message-input"
+        disabled={disabled}
+        required
+      />
       <button>
         <IoMdArrowUp className="chat-btn-arrow" />
       </button>

--- a/src/components/chat/ChatForm.tsx
+++ b/src/components/chat/ChatForm.tsx
@@ -1,4 +1,4 @@
-import { type Dispatch, type FormEvent, type SetStateAction, useRef } from "react";
+import { type Dispatch, type FormEvent, type SetStateAction, useEffect, useRef } from "react";
 import { IoMdArrowUp } from "react-icons/io";
 import { getAssistantResponse } from "./mockChatService";
 
@@ -8,10 +8,15 @@ interface ChatFormProps {
   setChatHistory: Dispatch<SetStateAction<ChatHistoryType[]>>;
   setIsThinking: Dispatch<SetStateAction<boolean>>;
   disabled: boolean;
+  showChatPopup: boolean;
 }
 
-const ChatForm = ({ setChatHistory, setIsThinking, disabled }: ChatFormProps) => {
+const ChatForm = ({ setChatHistory, setIsThinking, disabled, showChatPopup }: ChatFormProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [disabled, showChatPopup]);
 
   const handleSendMessage = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/chat/ChatForm.tsx
+++ b/src/components/chat/ChatForm.tsx
@@ -8,15 +8,15 @@ interface ChatFormProps {
   setChatHistory: Dispatch<SetStateAction<ChatHistoryType[]>>;
   setIsThinking: Dispatch<SetStateAction<boolean>>;
   disabled: boolean;
-  showChatPopup: boolean;
+  showChatWidget: boolean;
 }
 
-const ChatForm = ({ setChatHistory, setIsThinking, disabled, showChatPopup }: ChatFormProps) => {
+const ChatForm = ({ setChatHistory, setIsThinking, disabled, showChatWidget }: ChatFormProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
-  }, [disabled, showChatPopup]);
+  }, [disabled, showChatWidget]);
 
   const handleSendMessage = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/chat/ChatWidget.css
+++ b/src/components/chat/ChatWidget.css
@@ -188,6 +188,12 @@
   font-size: 0.95rem;
 }
 
+.chat-form .chat-message-input:disabled {
+  background: linear-gradient(135deg, #0339647e, #06579a8b);
+  border-radius: 32px;
+  cursor: not-allowed;
+}
+
 .chat-form button {
   display: none;
   align-items: center;

--- a/src/components/chat/ChatWidget.css
+++ b/src/components/chat/ChatWidget.css
@@ -4,7 +4,7 @@
   box-sizing: border-box;
 }
 
-#chat-popup-toggler {
+#chat-widget-toggler {
   position: fixed;
   bottom: 30px;
   right: 40px;
@@ -27,7 +27,7 @@
   color: #fff;
 }
 
-.chat-popup {
+.chat-widget {
   position: fixed;
   opacity: 0;
   pointer-events: none;
@@ -41,15 +41,16 @@
   transform: scale(0.2);
   transform-origin: bottom right;
   transition: all 0.2s ease;
+  border: 1px solid #00000039;
 }
 
-.chat-show-popup .chat-popup {
+.chat-show-widget .chat-widget {
   opacity: 1;
   pointer-events: auto;
   transform: scale(1);
 }
 
-.chat-show-popup #chat-popup-toggler {
+.chat-show-widget #chat-widget-toggler {
   transform: rotate(90deg);
   opacity: 0;
   pointer-events: none;

--- a/src/components/chat/ChatWidget.css
+++ b/src/components/chat/ChatWidget.css
@@ -67,6 +67,8 @@
   display: flex;
   gap: 10px;
   align-items: center;
+  text-align: center;
+  color: #fff;
 }
 
 .chat-logo-icon {
@@ -79,6 +81,7 @@
   font-size: 1.3rem;
   font-weight: 600;
   padding-top: 14px;
+  margin-bottom: 1rem;
 }
 
 .chat-header button {

--- a/src/components/chat/ChatWidget.css
+++ b/src/components/chat/ChatWidget.css
@@ -312,9 +312,19 @@
 .chat-body-onboarding {
   display: flex;
   flex-direction: column;
-  gap: 30px;
-  height: 260px;
-  margin: 70px;
+  align-items: center;
+  gap: 15px;
+  height: 300px;
+  margin: 50px 0;
+}
+
+.chat-body-onboarding .chat-body-onboarding-section:first-child {
+  margin-bottom: 30px;
+}
+
+.chat-body-onboarding-section {
+  margin-top: 0px;
+  width: 220px;
 }
 
 .chat-body-onboarding button {
@@ -326,10 +336,16 @@
   border: solid 1px #000;
   box-shadow: 0.5rem 0.5rem 1rem #000;
   padding: 8px;
+  width: 100%;
   cursor: pointer;
   transition: 0.3s ease;
 }
 
 .chat-body-onboarding button:hover {
   box-shadow: 0.1rem 0.1rem 1.2rem #000;
+}
+
+.chat-onboarding-btn-subtext {
+  margin-top: 15px;
+  color: #000;
 }

--- a/src/components/chat/ChatWidget.css
+++ b/src/components/chat/ChatWidget.css
@@ -129,6 +129,7 @@
   margin-bottom: 2px;
   border-radius: 50%;
   background-color: #06579a;
+  box-shadow: 0.2rem 0.2rem 0.4rem #000;
 }
 
 .chat-message-text {
@@ -139,6 +140,7 @@
   white-space: pre-line;
   font-size: 0.95rem;
   text-align: left;
+  box-shadow: 0.2rem 0.2rem 0.5rem #000;
 }
 
 .chat-assistant-message .chat-message-text {
@@ -170,7 +172,7 @@
   border-radius: 32px;
   outline: 1px solid #cccce5;
   margin: 0 15px 15px 15px;
-  box-shadow: 0 0 8px rgba(17, 72, 161, 0.3);
+  box-shadow: 0.6rem 0.6rem 1rem rgba(17, 72, 161, 0.3);
   transition: 0.1s ease;
 }
 
@@ -189,7 +191,7 @@
 }
 
 .chat-form .chat-message-input:disabled {
-  background: linear-gradient(135deg, #0339647e, #06579a8b);
+  background: #afb5b8af;
   border-radius: 32px;
   cursor: not-allowed;
 }
@@ -304,4 +306,30 @@
 
 .chat-message-text a:hover {
   color: #58a6ff;
+}
+
+/* Onboarding buttons */
+.chat-body-onboarding {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  height: 260px;
+  margin: 70px;
+}
+
+.chat-body-onboarding button {
+  background: linear-gradient(135deg, #06579a, #06579a8b);
+  font-size: 1.1rem;
+  color: #fff;
+  border: none;
+  border-radius: 15px;
+  border: solid 1px #000;
+  box-shadow: 0.5rem 0.5rem 1rem #000;
+  padding: 8px;
+  cursor: pointer;
+  transition: 0.3s ease;
+}
+
+.chat-body-onboarding button:hover {
+  box-shadow: 0.1rem 0.1rem 1.2rem #000;
 }

--- a/src/components/chat/ChatWidget.css
+++ b/src/components/chat/ChatWidget.css
@@ -348,4 +348,5 @@
 .chat-onboarding-btn-subtext {
   margin-top: 15px;
   color: #000;
+  text-align: center;
 }

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -21,8 +21,11 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   const isValidRecordId = useMemo(() => healthRecordId !== undefined && healthRecordId >= 0, [healthRecordId]);
 
+  // Fetch health record
   useEffect(() => {
-    if (showChatPopup && isValidRecordId && !healthRecord) {
+    const existingChatSession = localStorage.getItem(`chat-session-record-${healthRecordId}`);
+
+    if (showChatPopup && isValidRecordId && !healthRecord && !existingChatSession) {
       const fetchRecord = async () => {
         setIsThinking(true);
         try {
@@ -30,6 +33,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
           if (!res.ok) throw new Error("Failed to fetch health record");
           const data = await res.json();
           setHealthRecord(data);
+
           setChatHistory([
             {
               role: "assistant",
@@ -55,12 +59,13 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     }
   }, [showChatPopup, healthRecordId]);
 
+  // Scroll to the bottom of the chat body
   useEffect(() => {
     if (!chatBodyRef.current) return;
-    // Scroll to the bottom of the chat body when chat history changes
     chatBodyRef.current.scrollTo({ top: chatBodyRef.current.scrollHeight, behavior: "smooth" });
   }, [chatHistory, showChatPopup]);
 
+  // Save chat history to localStorage
   useEffect(() => {
     if (!showChatPopup && !isChatEnabled) return;
     if (isValidRecordId) {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -23,9 +23,10 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   // Health record fetching and chat initialization
   useEffect(() => {
+    if (!showChatPopup) return;
     const existingChatSession = localStorage.getItem(sessionKey);
 
-    if (showChatPopup && isValidRecordId && !healthRecord && !existingChatSession) {
+    if (isValidRecordId && !healthRecord && !existingChatSession) {
       const fetchRecord = async () => {
         setIsThinking(true);
         try {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -21,7 +21,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   if (healthRecord) console.log("Fetched Health Record:", healthRecord);
 
   useEffect(() => {
-    if (showChatPopup && healthRecordId! > 0) {
+    if (showChatPopup && healthRecordId !== undefined && healthRecordId > 0) {
       const fetchRecord = async () => {
         setIsThinking(true);
         try {
@@ -42,7 +42,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
             {
               role: "assistant",
               message:
-                "Hmm, I wasn’t able to load your health record just now. \nPlease check your connection and try again, or let me know if you'd like to troubleshoot together.",
+                "Hmm, I'm unable to read your health record just now. \nPlease check your connection and try again, or let me know if you'd like to troubleshoot together.",
             },
           ]);
           setHealthRecord(null);

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FaUserDoctor } from "react-icons/fa6";
 import { MdChat } from "react-icons/md";
 import { SlArrowDown } from "react-icons/sl";
@@ -19,8 +19,10 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   const [isThinking, setIsThinking] = useState(false);
   const chatBodyRef = useRef<HTMLDivElement>(null);
 
+  const isValidRecordId = useMemo(() => healthRecordId !== undefined && healthRecordId >= 0, [healthRecordId]);
+
   useEffect(() => {
-    if (showChatPopup && healthRecordId !== undefined && healthRecordId > 0 && !healthRecord) {
+    if (showChatPopup && isValidRecordId && !healthRecord) {
       const fetchRecord = async () => {
         setIsThinking(true);
         try {
@@ -61,7 +63,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   useEffect(() => {
     if (!showChatPopup && !isChatEnabled) return;
-    if (healthRecordId && healthRecordId > 0) {
+    if (isValidRecordId) {
       localStorage.setItem(`chat-session-record-${healthRecordId}`, JSON.stringify(chatHistory));
     } else {
       localStorage.setItem("chat-session-general", JSON.stringify(chatHistory));
@@ -75,12 +77,12 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     if (!confirm) return;
 
     setIsChatEnabled(true);
-    localStorage.removeItem(healthRecordId ? `chat-session-record-${healthRecordId}` : "chat-session-general");
+    localStorage.removeItem(isValidRecordId ? `chat-session-record-${healthRecordId}` : "chat-session-general");
   };
 
   const handleContinueChat = () => {
     const chatHistoryString = localStorage.getItem(
-      healthRecordId ? `chat-session-record-${healthRecordId}` : "chat-session-general"
+      isValidRecordId ? `chat-session-record-${healthRecordId}` : "chat-session-general"
     );
     console.log(JSON.parse(chatHistoryString!));
     if (chatHistoryString) setChatHistory(JSON.parse(chatHistoryString));

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -10,18 +10,16 @@ import "./ChatWidget.css";
 import { type ChatHistoryType, type HealthRecord } from "~/types";
 
 const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
+  const [healthRecord, setHealthRecord] = useState<HealthRecord | null>(null);
   const [showChatPopup, setShowChatPopup] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryType[]>([
     { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
   ]);
   const [isThinking, setIsThinking] = useState(false);
   const chatBodyRef = useRef<HTMLDivElement>(null);
-  const [healthRecord, setHealthRecord] = useState<HealthRecord | null>(null);
-
-  if (healthRecord) console.log("Fetched Health Record:", healthRecord);
 
   useEffect(() => {
-    if (showChatPopup && healthRecordId !== undefined && healthRecordId > 0) {
+    if (showChatPopup && healthRecordId !== undefined && healthRecordId > 0 && !healthRecord) {
       const fetchRecord = async () => {
         setIsThinking(true);
         try {
@@ -37,8 +35,8 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
           ]);
         } catch (error) {
           console.error("Error fetching health record:", error);
-          setChatHistory([
-            ...chatHistory,
+          setChatHistory((prev) => [
+            ...prev,
             {
               role: "assistant",
               message:

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -11,7 +11,7 @@ import { type ChatHistoryType, type HealthRecord } from "~/types";
 
 const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   const [healthRecord, setHealthRecord] = useState<HealthRecord | null>(null);
-  const [showChatPopup, setShowChatPopup] = useState(false);
+  const [showChatWidget, setShowChatWidget] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryType[]>([]);
   const [isThinking, setIsThinking] = useState(false);
 
@@ -51,7 +51,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   // Chat initialization
   useEffect(() => {
-    if (!showChatPopup) return;
+    if (!showChatWidget) return;
 
     const initializeChat = async () => {
       const existingChatSession = localStorage.getItem(sessionKey);
@@ -74,17 +74,17 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     };
 
     initializeChat();
-  }, [showChatPopup, healthRecordId]);
+  }, [showChatWidget, healthRecordId]);
 
   // Scroll to the bottom of the chat body
   useEffect(() => {
     if (!chatBodyRef.current) return;
     chatBodyRef.current.scrollTo({ top: chatBodyRef.current.scrollHeight, behavior: "smooth" });
-  }, [chatHistory, showChatPopup]);
+  }, [chatHistory, showChatWidget]);
 
   // Save chat history to localStorage
   useEffect(() => {
-    if (showChatPopup && chatHistory.length > 0) {
+    if (showChatWidget && chatHistory.length > 0) {
       try {
         localStorage.setItem(sessionKey, JSON.stringify(chatHistory));
       } catch (error) {
@@ -133,18 +133,18 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   };
 
   return (
-    <div className={showChatPopup ? "chat-show-popup" : ""}>
-      <button onClick={() => setShowChatPopup((prev) => !prev)} id="chat-popup-toggler">
+    <div className={showChatWidget ? "chat-show-widget" : ""}>
+      <button onClick={() => setShowChatWidget((prev) => !prev)} id="chat-widget-toggler">
         <MdChat className="chat-bubble" />
       </button>
-      <div className="chat-popup">
+      <div className="chat-widget">
         {/* Chat Header */}
         <div className="chat-header">
           <div className="chat-header-info">
             <FaUserDoctor className="chat-logo-icon" /> {/* placeholder logo */}
             <div className="chat-logo-text">PhisioLog</div>
           </div>
-          <button onClick={() => setShowChatPopup((prev) => !prev)}>
+          <button onClick={() => setShowChatWidget((prev) => !prev)}>
             <SlArrowDown />
           </button>
         </div>
@@ -195,7 +195,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
             setChatHistory={setChatHistory}
             setIsThinking={setIsThinking}
             disabled={chatHistory.length === 0}
-            showChatPopup={showChatPopup}
+            showChatWidget={showChatWidget}
           />
         </div>
       </div>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -16,7 +16,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
   ]);
   const [isThinking, setIsThinking] = useState(false);
-  const [interactionTypeSelected, setInteractionTypeSelected] = useState(false);
+  const [isChatEnabled, setInteractionTypeSelected] = useState(false);
   const chatBodyRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -77,7 +77,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
         </div>
 
         {/* Chat Body */}
-        {interactionTypeSelected || healthRecordId ? (
+        {isChatEnabled || healthRecordId ? (
           <div ref={chatBodyRef} className="chat-body">
             {chatHistory.map((chat, index) => (
               <div key={index} className={`chat-message chat-${chat.role}-message`}>
@@ -112,7 +112,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
         {/* Chat Footer */}
         <div className="chat-footer">
-          <ChatForm setChatHistory={setChatHistory} setIsThinking={setIsThinking} />
+          <ChatForm setChatHistory={setChatHistory} setIsThinking={setIsThinking} disabled={!isChatEnabled} />
         </div>
       </div>
     </div>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -104,7 +104,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
             )}
           </div>
         ) : (
-          <div className="chat-body">
+          <div className="chat-body-onboarding">
             <button onClick={() => setInteractionTypeSelected(true)}>Create New Interaction</button>
             <button onClick={() => setInteractionTypeSelected(true)}>Edit Existing Interaction</button>
           </div>
@@ -112,7 +112,12 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
         {/* Chat Footer */}
         <div className="chat-footer">
-          <ChatForm setChatHistory={setChatHistory} setIsThinking={setIsThinking} disabled={!isChatEnabled} />
+          <ChatForm
+            setChatHistory={setChatHistory}
+            setIsThinking={setIsThinking}
+            disabled={!isChatEnabled}
+            showChatPopup={showChatPopup}
+          />
         </div>
       </div>
     </div>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -115,7 +115,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
           <ChatForm
             setChatHistory={setChatHistory}
             setIsThinking={setIsThinking}
-            disabled={!isChatEnabled}
+            disabled={!isChatEnabled && healthRecordId == null}
             showChatPopup={showChatPopup}
           />
         </div>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -9,13 +9,24 @@ import ChatForm from "./ChatForm";
 import "./ChatWidget.css";
 import type { ChatHistoryType } from "~/types";
 
-const ChatWidget = () => {
+const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   const [showChatPopup, setShowChatPopup] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryType[]>([
     { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
   ]);
   const [isThinking, setIsThinking] = useState(false);
   const chatBodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (healthRecordId) {
+      setChatHistory([
+        {
+          role: "assistant",
+          message: `I see you're working with **#${healthRecordId}** record. How can I help you update it?`,
+        },
+      ]);
+    }
+  }, [healthRecordId]);
 
   useEffect(() => {
     if (!chatBodyRef.current) return;

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -16,6 +16,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
   ]);
   const [isThinking, setIsThinking] = useState(false);
+  const [interactionTypeSelected, setInteractionTypeSelected] = useState(false);
   const chatBodyRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -76,31 +77,38 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
         </div>
 
         {/* Chat Body */}
-        <div ref={chatBodyRef} className="chat-body">
-          {chatHistory.map((chat, index) => (
-            <div key={index} className={`chat-message chat-${chat.role}-message`}>
-              {chat.role === "assistant" && <FaUserDoctor className="chat-logo-icon" />}
-              <div className="chat-message-text">
-                <ReactMarkdown
-                  components={{ a: ({ ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" /> }}
-                  remarkPlugins={[remarkGfm]}
-                >
-                  {chat.message}
-                </ReactMarkdown>
+        {interactionTypeSelected || healthRecordId ? (
+          <div ref={chatBodyRef} className="chat-body">
+            {chatHistory.map((chat, index) => (
+              <div key={index} className={`chat-message chat-${chat.role}-message`}>
+                {chat.role === "assistant" && <FaUserDoctor className="chat-logo-icon" />}
+                <div className="chat-message-text">
+                  <ReactMarkdown
+                    components={{ a: ({ ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" /> }}
+                    remarkPlugins={[remarkGfm]}
+                  >
+                    {chat.message}
+                  </ReactMarkdown>
+                </div>
               </div>
-            </div>
-          ))}
-          {isThinking && (
-            <div className="chat-message chat-assistant-message">
-              <FaUserDoctor className="chat-logo-icon" />
-              <div className="chat-message-text chat-thinking-dots">
-                <span></span>
-                <span></span>
-                <span></span>
+            ))}
+            {isThinking && (
+              <div className="chat-message chat-assistant-message">
+                <FaUserDoctor className="chat-logo-icon" />
+                <div className="chat-message-text chat-thinking-dots">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </div>
               </div>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        ) : (
+          <div className="chat-body">
+            <button onClick={() => setInteractionTypeSelected(true)}>Create New Interaction</button>
+            <button onClick={() => setInteractionTypeSelected(true)}>Edit Existing Interaction</button>
+          </div>
+        )}
 
         {/* Chat Footer */}
         <div className="chat-footer">

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -21,9 +21,12 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   const isValidRecordId = useMemo(() => healthRecordId !== undefined && healthRecordId >= 0, [healthRecordId]);
 
-  // Fetch health record
+  // Health record fetching and chat initialization
   useEffect(() => {
-    const existingChatSession = localStorage.getItem(`chat-session-record-${healthRecordId}`);
+    const existingChatSession = localStorage.getItem(
+      isValidRecordId ? `chat-session-record-${healthRecordId}` : "chat-session-general"
+    );
+    if (!existingChatSession) setIsChatEnabled(true);
 
     if (showChatPopup && isValidRecordId && !healthRecord && !existingChatSession) {
       const fetchRecord = async () => {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -114,8 +114,14 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
           </div>
         ) : (
           <div className="chat-body-onboarding">
-            <button onClick={() => setIsChatEnabled(true)}>Create New Interaction</button>
-            <button onClick={() => setIsChatEnabled(true)}>Edit Existing Interaction</button>
+            <div className="chat-body-onboarding-section">
+              <button onClick={() => setIsChatEnabled(true)}>Start New Chat</button>
+              <p className="chat-onboarding-btn-subtext">Begin a new conversation with your PhisioLog Assistant.</p>
+            </div>
+            <div className="chat-body-onboarding-section">
+              <button onClick={() => setIsChatEnabled(true)}>Continue Chat</button>
+              <p className="chat-onboarding-btn-subtext">Pick up from where you left off in your last session.</p>
+            </div>
           </div>
         )}
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -62,11 +62,25 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   useEffect(() => {
     if (!showChatPopup) return;
     if (healthRecordId && healthRecordId > 0) {
-      localStorage.setItem("chat_session_record", JSON.stringify(chatHistory));
+      localStorage.setItem(`chat-session-record-${healthRecordId}`, JSON.stringify(chatHistory));
     } else {
-      localStorage.setItem("chat_session_general", JSON.stringify(chatHistory));
+      localStorage.setItem("chat-session-general", JSON.stringify(chatHistory));
     }
   }, [chatHistory]);
+
+  const handleNewChat = (mode?: string) => {
+    const confirm = window.confirm(
+      "Starting a new chat will erase your previous chat session! Do you want to continue?"
+    );
+    if (!confirm) return;
+
+    setIsChatEnabled(true);
+    if (mode === "editMode") {
+      localStorage.removeItem(`chat-session-record-${healthRecordId}`);
+    } else {
+      localStorage.removeItem("chat-session-general");
+    }
+  };
 
   return (
     <div className={showChatPopup ? "chat-show-popup" : ""}>
@@ -115,11 +129,11 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
         ) : (
           <div className="chat-body-onboarding">
             <div className="chat-body-onboarding-section">
-              <button onClick={() => setIsChatEnabled(true)}>Start New Chat</button>
+              <button onClick={() => handleNewChat()}>Start New Chat</button>
               <p className="chat-onboarding-btn-subtext">Begin a new conversation with your PhisioLog Assistant.</p>
             </div>
             <div className="chat-body-onboarding-section">
-              <button onClick={() => setIsChatEnabled(true)}>Continue Chat</button>
+              <button onClick={() => handleNewChat("editMode")}>Continue Chat</button>
               <p className="chat-onboarding-btn-subtext">Pick up from where you left off in your last session.</p>
             </div>
           </div>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -16,7 +16,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
   ]);
   const [isThinking, setIsThinking] = useState(false);
-  const [isChatEnabled, setInteractionTypeSelected] = useState(false);
+  const [isChatEnabled, setIsChatEnabled] = useState(false);
   const chatBodyRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -58,6 +58,15 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     // Scroll to the bottom of the chat body when chat history changes
     chatBodyRef.current.scrollTo({ top: chatBodyRef.current.scrollHeight, behavior: "smooth" });
   }, [chatHistory, showChatPopup]);
+
+  useEffect(() => {
+    if (!showChatPopup) return;
+    if (healthRecordId && healthRecordId > 0) {
+      localStorage.setItem("chat_session_record", JSON.stringify(chatHistory));
+    } else {
+      localStorage.setItem("chat_session_general", JSON.stringify(chatHistory));
+    }
+  }, [chatHistory]);
 
   return (
     <div className={showChatPopup ? "chat-show-popup" : ""}>
@@ -105,8 +114,8 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
           </div>
         ) : (
           <div className="chat-body-onboarding">
-            <button onClick={() => setInteractionTypeSelected(true)}>Create New Interaction</button>
-            <button onClick={() => setInteractionTypeSelected(true)}>Edit Existing Interaction</button>
+            <button onClick={() => setIsChatEnabled(true)}>Create New Interaction</button>
+            <button onClick={() => setIsChatEnabled(true)}>Edit Existing Interaction</button>
           </div>
         )}
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -14,7 +14,9 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   const [showChatPopup, setShowChatPopup] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryType[]>([]);
   const [isThinking, setIsThinking] = useState(false);
+
   const chatBodyRef = useRef<HTMLDivElement>(null);
+
   const isValidRecordId = useMemo(() => healthRecordId !== undefined && healthRecordId >= 0, [healthRecordId]);
   const sessionKey = useMemo(
     () => (isValidRecordId ? `chat-session-record-${healthRecordId}` : "chat-session-general"),
@@ -117,9 +119,9 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   const handleContinueChat = () => {
     try {
-      const chatHistoryString = localStorage.getItem(sessionKey);
-      if (chatHistoryString) {
-        const parsedChatHistory = JSON.parse(chatHistoryString);
+      const savedSession = localStorage.getItem(sessionKey);
+      if (savedSession) {
+        const parsedChatHistory = JSON.parse(savedSession);
         setChatHistory(parsedChatHistory);
       }
     } catch (error) {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -70,7 +70,7 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
         <div className="chat-header">
           <div className="chat-header-info">
             <FaUserDoctor className="chat-logo-icon" /> {/* placeholder logo */}
-            <h2 className="chat-logo-text">PhisioLog</h2>
+            <div className="chat-logo-text">PhisioLog</div>
           </div>
           <button onClick={() => setShowChatPopup((prev) => !prev)}>
             <SlArrowDown />

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -80,9 +80,19 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
     );
     if (!confirm) return;
     localStorage.removeItem(sessionKey);
-    setChatHistory([
-      { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
-    ]);
+
+    if (isValidRecordId && healthRecord) {
+      setChatHistory([
+        {
+          role: "assistant",
+          message: `I see you're working with **${healthRecord.title}** record. How can I help you update it?`,
+        },
+      ]);
+    } else {
+      setChatHistory([
+        { role: "assistant", message: "Hello 👋!!!\nI'm your PhisioLog Assistant. How can I help you today?" },
+      ]);
+    }
   };
 
   const handleContinueChat = () => {
@@ -137,12 +147,12 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
         ) : (
           <div className="chat-body-onboarding">
             <div className="chat-body-onboarding-section">
-              <button onClick={handleNewChat}>Start New Chat</button>
-              <p className="chat-onboarding-btn-subtext">Begin a new conversation with your PhisioLog Assistant.</p>
-            </div>
-            <div className="chat-body-onboarding-section">
               <button onClick={handleContinueChat}>Continue Chat</button>
               <p className="chat-onboarding-btn-subtext">Pick up from where you left off in your last session.</p>
+            </div>
+            <div className="chat-body-onboarding-section">
+              <button onClick={handleNewChat}>Start New Chat</button>
+              <p className="chat-onboarding-btn-subtext">Begin a new conversation with your PhisioLog Assistant.</p>
             </div>
           </div>
         )}

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -71,7 +71,13 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
 
   // Save chat history to localStorage
   useEffect(() => {
-    if (showChatPopup && chatHistory.length > 0) localStorage.setItem(sessionKey, JSON.stringify(chatHistory));
+    if (showChatPopup && chatHistory.length > 0) {
+      try {
+        localStorage.setItem(sessionKey, JSON.stringify(chatHistory));
+      } catch (error) {
+        console.error("Failed to save chat session:", error);
+      }
+    }
   }, [chatHistory]);
 
   const handleNewChat = () => {
@@ -96,8 +102,18 @@ const ChatWidget = ({ healthRecordId }: { healthRecordId?: number }) => {
   };
 
   const handleContinueChat = () => {
-    const chatHistoryString = localStorage.getItem(sessionKey);
-    if (chatHistoryString) setChatHistory(JSON.parse(chatHistoryString));
+    try {
+      const chatHistoryString = localStorage.getItem(sessionKey);
+      if (chatHistoryString) {
+        const parsedChatHistory = JSON.parse(chatHistoryString);
+        setChatHistory(parsedChatHistory);
+      }
+    } catch (error) {
+      console.error("Failed to load chat session:", error);
+      setChatHistory([
+        { role: "assistant", message: "I couldn't retrieve your previous conversation! Let's start a new chat!" },
+      ]);
+    }
   };
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,7 +37,7 @@ const Home = () => (
     </section>
 
     <HealthRecordsManager />
-    <ChatWidget healthRecordId={1} />
+    <ChatWidget />
   </div>
 );
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,7 +37,7 @@ const Home = () => (
     </section>
 
     <HealthRecordsManager />
-    <ChatWidget />
+    <ChatWidget healthRecordId={1} />
   </div>
 );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ interface Update {
 export interface HealthRecord {
   id?: number;
   user?: string;
+  title: string;
   description: string;
   symptoms: Symptom[];
   status: Status;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ interface Update {
 export interface HealthRecord {
   id?: number;
   user?: string;
-  title: string;
+  title?: string;
   description: string;
   symptoms: Symptom[];
   status: Status;


### PR DESCRIPTION
### Summary

- Implemented contextual entry handling:
  - Chat properly detects whether launched from a global entry point (without context) or specific health record (with context)
- Added onboarding prompt with `Continue Chat` and `New Chat` buttons:
  - Message input is disabled until selection is made
  - Buttons are hidden after selection is made
- Built session persistence using local storage:
  - Chat sessions are restored if available
  - Sessions are tied to correct context
- Improved and added some new styles

#### Important Note:
Issue description asked for following: `If context is passed, skip onboarding and initialize the chat in update mode using provided record`, and also `Restore the session on widget re-entry if available`.

My implementation and view on that:
No buttons are displayed unless there is a chat session in local storage regardless of context being passed or not. If there is a previous session, instead of restoring it automatically on widget re-entry, user is presented with a choice to either continue previous session or start a new chat.

So, I believe opening chat widget should trigger onboarding buttons only if there is a session from before, context or no-context related. Otherwise, skip onboarding buttons and depending on where chat widget is opened from, either directly show a welcome message (no context, general discussion), or initial message related to particular health record.

### How to Test

Chat widget is added to a Home Page (no context), and a Health Record Form (context) for testing.

### Checklist

- [x] My code is up-to-date with the `main` branch.
- [x] My code has no merge conflicts.
- [x] I have performed a self-review of my code.
