### PR TITLE
feat: Add edit navigation and empty state handling

### DIFF
--- a/src/components/HealthCard.tsx
+++ b/src/components/HealthCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import "./HealthCard.css";
 import type { HealthRecord } from "~/types";
@@ -6,6 +7,7 @@ import type { HealthRecord } from "~/types";
 const HealthCard = ({ record }: { record: HealthRecord }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const latestConsultation = record.medicalConsultations[record.medicalConsultations.length - 1];
+  const navigate = useNavigate();
 
   return (
     <li className="health-card">
@@ -22,7 +24,7 @@ const HealthCard = ({ record }: { record: HealthRecord }) => {
           <button onClick={() => setIsExpanded(!isExpanded)} className="details-toggle">
             {isExpanded ? "Show Less" : "Show More"}
           </button>
-          <button className="edit-button" onClick={() => alert("This is a placeholder...")}>
+          <button className="edit-button" onClick={() => navigate(`/health-record/edit/${record.id}`)}>
             Edit
           </button>
         </div>

--- a/src/components/HealthCardsGrid.css
+++ b/src/components/HealthCardsGrid.css
@@ -49,22 +49,42 @@
 }
 
 .edit-btn {
-  background-color: #ff4444;
+  background-color: #007bff;
   color: white;
+  padding: 0.5rem 1rem;
   border: none;
-  border-radius: 20px;
-  padding: 8px 16px;
+  border-radius: 4px;
   cursor: pointer;
-  font-size: 14px;
-  transition: background-color 0.2s ease;
+  font-size: 0.9rem;
+  transition: background-color 0.3s ease;
 }
 
 .edit-btn:hover {
-  background-color: #680101;
+  background-color: #0056b3;
 }
 
 .edit-btn:active {
   background-color: #cc0000;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem;
+  background: #f5f5f5;
+  border-radius: 8px;
+  margin: 2rem auto;
+  max-width: 500px;
+}
+
+.empty-state p {
+  margin: 0.5rem 0;
+  color: #666;
+}
+
+.empty-state p:first-child {
+  font-size: 1.2rem;
+  color: #333;
+  font-weight: bold;
 }
 
 @media (max-width: 1400px) {

--- a/src/components/HealthCardsGrid.tsx
+++ b/src/components/HealthCardsGrid.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 import "./HealthCardsGrid.css";
 import type { HealthRecord } from "~/types";
 
@@ -7,6 +9,8 @@ interface HealthCardsGridProps {
 }
 
 const HealthsCardsGrid = ({ records, onClick }: HealthCardsGridProps) => {
+  const navigate = useNavigate();
+
   return (
     <div className="grid-container">
       <div className="grid">
@@ -27,7 +31,7 @@ const HealthsCardsGrid = ({ records, onClick }: HealthCardsGridProps) => {
                   className="edit-btn"
                   onClick={(e) => {
                     e.stopPropagation();
-                    alert("This is only a placeholder");
+                    navigate(`/health-record/edit/${record.id}`);
                   }}
                 >
                   Edit

--- a/src/components/HealthModal.css
+++ b/src/components/HealthModal.css
@@ -112,3 +112,30 @@
 .health-record-details {
   width: 100%;
 }
+
+.modal-actions {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #eee;
+  text-align: right;
+}
+
+.edit-modal-button {
+  background-color: #007bff;
+  color: white;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.3s ease;
+}
+
+.edit-modal-button:hover {
+  background-color: #0056b3;
+}
+
+.modal-actions {
+  position: relative;
+  z-index: 1000;
+}

--- a/src/components/HealthModal.tsx
+++ b/src/components/HealthModal.tsx
@@ -1,4 +1,5 @@
 import { IoChevronBack, IoChevronForward, IoClose } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
 
 import "./HealthModal.css";
 import body from "~/assets/img/body.png";
@@ -13,6 +14,7 @@ interface HealthModalProps {
 
 const HealthModal = ({ record, onClose, onNext, onPrev }: HealthModalProps) => {
   const latestConsultation = record.medicalConsultations[record.medicalConsultations.length - 1];
+  const navigate = useNavigate();
 
   return (
     <div className="modal-overlay">
@@ -52,6 +54,17 @@ const HealthModal = ({ record, onClose, onNext, onPrev }: HealthModalProps) => {
                     <strong>Follow-up Actions:</strong> {latestConsultation.followUpActions.join(", ")}
                   </p>
                 )}
+                <div className="modal-actions">
+                  <button
+                    className="edit-modal-button"
+                    onClick={() => {
+                      navigate(`/health-record/edit/${record.id}`);
+                      onClose();
+                    }}
+                  >
+                    Edit Record
+                  </button>
+                </div>
               </div>
               <div className="details-img">
                 <img src={body} alt="Next" width={90} height={210} /> {/* Placeholder for body map image */}

--- a/src/components/HealthRecordsManager.tsx
+++ b/src/components/HealthRecordsManager.tsx
@@ -11,7 +11,13 @@ const HealthRecordsManager = () => {
   useEffect(() => {
     fetch("http://localhost:4444/health-records")
       .then((response) => response.json())
-      .then((data) => setRecords(data));
+      .then((data) => {
+        // if you want to test empty state comment line below
+        setRecords(data);
+
+        // and use this one:
+        //setRecords([]);
+      });
   }, []);
 
   const handleNext = () => {
@@ -31,7 +37,14 @@ const HealthRecordsManager = () => {
     <div className="home">
       <h2>Health Records</h2>
       <div className="health-records-grid">
-        <HealthCardGrid records={records} onClick={handleRecordClick} />
+        {records.length === 0 ? (
+          <div className="empty-state">
+            <p>No health records available.</p>
+            <p>This is a placeholder with instruction to create your first health record.</p>
+          </div>
+        ) : (
+          <HealthCardGrid records={records} onClick={handleRecordClick} />
+        )}
       </div>
 
       {selectedIndex !== null && (


### PR DESCRIPTION
- Added edit buttons to all health record views (grid, expanded card, modal)
- Implemented navigation to edit page
- Added empty state message for no records
- Updated CSS styles for consistency

### Summary

Please include a summary of the changes and the related issue. Be concise but informative.

### How to Test

If your changes are not obvious, please provide a brief description of how to test the changes you made.

### Checklist

- [✅ ] My code is up-to-date with the `main` branch.
- [✅] My code has no merge conflicts.
- [✅ ] I have performed a self-review of my code.


# Enhance Home Component with Edit Navigation and Empty State

This PR implements navigation to Edit Health Record and empty state handling as requested in the issue.

## Implementation Details

### 1. Edit Navigation
Added edit buttons in both record views:
- Grid view cards
- Modal detail view

Navigation implemented using React Router's `useNavigate` hook, currently routing to `/health-record/edit/${recordId}`.

### 2. Empty State Handling
Added user-friendly message when no records are available:
- Clear message appears in the main content area
- Layout remains consistent
- Easy to understand call-to-action

## How to Test

### Testing Edit Navigation
1. Grid View:
   - Click edit button on any card
   - Verify navigation to edit page

2. Modal View:
   - Click on any card to open modal
   - Click edit button in modal
   - Verify navigation and modal closing

### Testing Empty State
To test empty state scenario, in `HealthRecordsManager.tsx`:
```typescript
useEffect(() => {
  fetch("http://localhost:4444/health-records")
    .then((response) => response.json())
    .then((data) => {
      // Comment this line to test empty state
      setRecords(data);
      
      // Uncomment this line to test empty state
      // setRecords([]);
    });
}, []);